### PR TITLE
Add job to clean-up docker items on workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,17 +10,17 @@ pipeline {
             }
         }
 
-    stage('Publish') {
-      when {
-        branch 'master'
-      }
-      steps {
-        withDockerRegistry([ credentialsId: "dockerhub-user", url: "" ]) {
-          sh 'docker push adhocteam/jenkins:latest'
+        stage('Publish') {
+            when {
+                branch 'master'
+            }
+            steps {
+                withDockerRegistry([ credentialsId: "dockerhub-user", url: "" ]) {
+                sh 'docker push adhocteam/jenkins:latest'
+                }
+            }
         }
-      }
     }
-
     post {
         always {
             deleteDir()

--- a/as-code/jobs.yaml
+++ b/as-code/jobs.yaml
@@ -2,3 +2,4 @@ jobs:
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/slack_setup.groovy
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/disable_telemetry.groovy
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/setup_gh_org_folder.groovy
+  - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/docker_cleanup.groovy

--- a/jobs/docker_cleanup.groovy
+++ b/jobs/docker_cleanup.groovy
@@ -1,0 +1,36 @@
+job('docker-cleanup') {
+    displayName('Docker clean-up')
+    description('Cleans up all left-over docker item to prevent the hard-drive filling up')
+
+    triggers {
+        cron('H H * * *')
+    }
+
+    parameters {
+        labelParam('Workers') {
+            defaultValue('worker')
+            description('Select nodes')
+            allNodes('allCases', 'IgnoreOfflineNodeEligibility')
+        }
+    }
+
+    steps {
+        shell( '''
+        set -xe
+
+        docker system df -v
+
+        docker system prune -af --volumes --filter "until=24h"
+
+        docker system df -v
+        df -h
+        ''')
+    }
+
+    logRotator {
+        daysToKeep(7)
+    }
+}
+
+
+


### PR DESCRIPTION
This breaks out our current docker clean-up job into its own job definition. This will make it portable between Jenkins instances and reloadable on each start-up.

The docker clean-up is pretty drastic. It cleans everything out. But, for most CI/CD use cases this is okay as you only pay any "reload" price once per day and in most cases you'll be building from scratch anyway.