### PR TITLE
Add TagDiscovery to our default Jenkins build

### DIFF
--- a/jobs/setup_gh_org_folder.groovy
+++ b/jobs/setup_gh_org_folder.groovy
@@ -23,6 +23,7 @@ organizationFolder('Adhocteam Github') {
         traits << 'org.jenkinsci.plugins.github__branch__source.OriginPullRequestDiscoveryTrait' {
             strategyId 1
         }
+        traits << 'org.jenkinsci.plugins.github__branch__source.TagDiscoveryTrait'
     }
 
     // "Project Recognizers"


### PR DESCRIPTION
### Adds Tag Discovery to our Default Jenkins Build

Related to https://github.com/adhocteam/adhoc_co/pull/1246

### Proposed changes:

- Adds Tag Discovery to our seed job for our Ad Hoc github org

Adding here will ensure that that feature remains enables when we upgrade/redeploy the Jenkins primary for the security fixes (which we'll need to do soon!)

### Acceptance criteria validation

- [X] Enables tag discovery by default
