### PR TITLE
Add authorize-project plugin to address Jenkins warning

### DIFF
--- a/as-code/main.yaml
+++ b/as-code/main.yaml
@@ -32,7 +32,3 @@ tool:
 unclassified:
   location:
     url: ${jenkins_url}
-  queueItemAuthenticator:
-    authenticators:
-      - global:
-          strategy: triggeringUsersAuthorizationStrategy

--- a/as-code/main.yaml
+++ b/as-code/main.yaml
@@ -32,3 +32,7 @@ tool:
 unclassified:
   location:
     url: ${jenkins_url}
+  queueItemAuthenticator:
+    authenticators:
+      - global:
+          strategy: triggeringUsersAuthorizationStrategy

--- a/init.groovy.d/configure_auth_projects.groovy
+++ b/init.groovy.d/configure_auth_projects.groovy
@@ -1,0 +1,23 @@
+import jenkins.security.QueueItemAuthenticatorConfiguration
+import org.jenkinsci.plugins.authorizeproject.GlobalQueueItemAuthenticator
+import org.jenkinsci.plugins.authorizeproject.strategy.SystemAuthorizationStrategy
+import hudson.model.AdministrativeMonitor;
+
+
+
+// Configure the plugin and set to run as System user
+// This will happen anyway because GitHub triggered jobs run as System
+GlobalQueueItemAuthenticator auth = new GlobalQueueItemAuthenticator(
+    new SystemAuthorizationStrategy()
+)
+QueueItemAuthenticatorConfiguration.get().authenticators.add(auth)
+
+// Suppress the warning since it doesn't like System jobs
+// From reviewing the code it looks like it fires in error for us
+// because it doesn't properly see that our GitHub auth strategy
+// restricts who can run jobs to just trusted users
+AdministrativeMonitor.all().each {
+  if (it.getDisplayName() == 'Access Control for Builds') {
+   it.disable(true)
+  }
+}

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,3 +1,4 @@
+authorize-project
 basic-branch-build-strategies:latest
 blueocean:latest
 blueocean-github-pipeline:latest


### PR DESCRIPTION
### Resolves Jenkins security warning

Removes this warning banner from Jenkins

![image](https://user-images.githubusercontent.com/6646098/54728880-50677300-4b4e-11e9-86b6-9cabfe9b74c9.png)


### Proposed changes:

- Add `authorize-project` to plugins
- Add automatic configuration code

Jenkins added that warning banner in its last release in response to https://issues.jenkins-ci.org/browse/JENKINS-24513

The suggested remedy to install and configure the [Authorize Project](https://plugins.jenkins.io/authorize-project) plugin.

### Acceptance criteria validation

- [ ] Banner no longer shows on deploying a fresh Jenkins primary instance

#### Security implications

This closes a vulnerability in Jenkins where a user with access to one Job could leverage that to run other Jobs that potentially could impact the underlying system.

In our case, we only allow in "trusted" users via GitHub auth and don't allow (for example) running of PRs from forks. So the actual risk factor here for us is low, but it's good to resolve that error banner so it doesn't continue to show in the future.