### PR TITLE
Try to add build strategies to build tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
 
             steps {
                 script {
-                    TAG = "${BRANCH_NAME}"
+                    TAG=BRANCH_NAME.split('/').last()
                 }
             }
         }

--- a/as-code/jobs.yaml
+++ b/as-code/jobs.yaml
@@ -1,4 +1,4 @@
 jobs:
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/disable_telemetry.groovy
-  - url: https://raw.githubusercontent.com/adhocteam/jenkins/ce20ebe5555cd2b6c1978a88980d4fa4f9e2c370/jobs/setup_gh_org_folder.groovy
+  - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/setup_gh_org_folder.groovy
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/docker_cleanup.groovy

--- a/as-code/jobs.yaml
+++ b/as-code/jobs.yaml
@@ -1,5 +1,3 @@
 jobs:
-  - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/disable_telemetry.groovy
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/setup_gh_org_folder.groovy
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/docker_cleanup.groovy
-

--- a/as-code/jobs.yaml
+++ b/as-code/jobs.yaml
@@ -1,3 +1,4 @@
 jobs:
-  - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/setup_gh_org_folder.groovy
+  - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/disable_telemetry.groovy
+  - url: https://raw.githubusercontent.com/adhocteam/jenkins/ce20ebe5555cd2b6c1978a88980d4fa4f9e2c370/jobs/setup_gh_org_folder.groovy
   - url: https://raw.githubusercontent.com/adhocteam/jenkins/master/jobs/docker_cleanup.groovy

--- a/jobs/setup_gh_org_folder.groovy
+++ b/jobs/setup_gh_org_folder.groovy
@@ -36,6 +36,14 @@ organizationFolder('Adhocteam Github') {
             strategyId 1
         }
         traits << 'org.jenkinsci.plugins.github__branch__source.TagDiscoveryTrait' {}
+
+
+
+        // Build strategies not available on Org Folders so doing it here
+        def buildStrategies = it / 'buildStrategies'
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.BranchBuildStrategyImpl' {}
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl' {}
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.TagBuildStrategyImpl' {}
     }
 
     // "Project Recognizers"

--- a/jobs/setup_gh_org_folder.groovy
+++ b/jobs/setup_gh_org_folder.groovy
@@ -11,18 +11,6 @@ organizationFolder('Adhocteam Github') {
         }
     }
 
-    buildStrategies {
-        buildRegularBranches()
-        buildChangeRequests {
-            ignoreTargetOnlyChanges(false)
-        }
-        buildTags {
-            atLeastDays ''
-            // only build tags which were created within the past 24 hours
-            atMostDays '1'
-        }
-    }
-
     configure {
         def traits = it / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
         traits << 'org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait' {
@@ -42,8 +30,13 @@ organizationFolder('Adhocteam Github') {
         // Build strategies not available on Org Folders so doing it here
         def buildStrategies = it / 'buildStrategies'
         buildStrategies << 'jenkins.branch.buildstrategies.basic.BranchBuildStrategyImpl' {}
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl' {}
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.TagBuildStrategyImpl' {}
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl' {
+            ignoreTargetOnlyChanges(false)
+        }
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.TagBuildStrategyImpl' {
+            atLeastDays ''
+            atMostDays '1'
+        }
     }
 
     // "Project Recognizers"

--- a/jobs/setup_gh_org_folder.groovy
+++ b/jobs/setup_gh_org_folder.groovy
@@ -11,6 +11,18 @@ organizationFolder('Adhocteam Github') {
         }
     }
 
+    buildStrategies {
+        buildRegularBranches()
+        buildChangeRequests {
+            ignoreTargetOnlyChanges(false)
+        }
+        buildTags {
+            atLeastDays ''
+            // only build tags which were created within the past 24 hours
+            atMostDays '1'
+        }
+    }
+
     configure {
         def traits = it / navigators / 'org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator' / traits
         traits << 'org.jenkinsci.plugins.github_branch_source.BranchDiscoveryTrait' {

--- a/jobs/setup_gh_org_folder.groovy
+++ b/jobs/setup_gh_org_folder.groovy
@@ -29,13 +29,14 @@ organizationFolder('Adhocteam Github') {
 
         // Build strategies not available on Org Folders so doing it here
         def buildStrategies = it / 'buildStrategies'
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.BranchBuildStrategyImpl' {}
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl' {
-            ignoreTargetOnlyChanges(false)
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.BranchBuildStrategyImpl plugin="basic-branch-build-strategies@1.2.0"' {}
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl plugin="basic-branch-build-strategies@1.2.0"' {
+            ignoreTargetOnlyChanges false
+            ignoreUntrustedChanges false
         }
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.TagBuildStrategyImpl' {
-            atLeastDays ''
-            atMostDays '1'
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.TagBuildStrategyImpl plugin="basic-branch-build-strategies@1.2.0"' {
+            atLeastMillis '-1'
+            atMostMillis '86400000'
         }
     }
 

--- a/jobs/setup_gh_org_folder.groovy
+++ b/jobs/setup_gh_org_folder.groovy
@@ -28,13 +28,12 @@ organizationFolder('Adhocteam Github') {
 
 
         // Build strategies not available on Org Folders so doing it here
-        def buildStrategies = it / 'buildStrategies'
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.BranchBuildStrategyImpl plugin="basic-branch-build-strategies@1.2.0"' {}
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl plugin="basic-branch-build-strategies@1.2.0"' {
+        def buildStrategies = it / buildStrategies
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.BranchBuildStrategyImpl' {}
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.ChangeRequestBuildStrategyImpl' {
             ignoreTargetOnlyChanges false
-            ignoreUntrustedChanges false
         }
-        buildStrategies << 'jenkins.branch.buildstrategies.basic.TagBuildStrategyImpl plugin="basic-branch-build-strategies@1.2.0"' {
+        buildStrategies << 'jenkins.branch.buildstrategies.basic.TagBuildStrategyImpl' {
             atLeastMillis '-1'
             atMostMillis '86400000'
         }


### PR DESCRIPTION
<!-- If fixing a bug, add `?template=BUG.md` to the end of the URL to use that template instead -->
<!-- If changing only documentation, add `?template=DOCUMENTATION.md` to the end of the URL to use that template instead -->

### Adds Build Strategy for Tags

The default build strategy is ["build everything except for tags"](https://github.com/jenkinsci/basic-branch-build-strategies-plugin/blob/master/docs/user.adoc) so we did not need a build strategy. The discover strategy resulted in our building everything we found.

To build tags though, we need to update the build strategy to include them.

### Proposed changes:

- Add configuration to our GitHub org folder for setting the build strategy

### Acceptance criteria validation

- [X] Fulfilled Acceptance Criteria
- [X] Tests added to cover the change

Successful test run of new seed job here: https://jenkins.adhoc.team/job/Seedjob/1/console